### PR TITLE
Improved: Use HC Shipment Item Seq Id to update external Id for Store TO Fulfillment Feed

### DIFF
--- a/component.xml
+++ b/component.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/moqui-conf-3.xsd"
-   name="mantle-netsuite-connector" version="1.5.2">
+   name="mantle-netsuite-connector" version="1.5.3">
 </component>

--- a/data/SystemMessageData.xml
+++ b/data/SystemMessageData.xml
@@ -172,17 +172,8 @@
          sendPath="${contentRoot}/netsuite/StoreToFulfillmentFeed">
     </moqui.service.message.SystemMessageType>
 
-    <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateOMSUpdateTOShipmentFeed"
-           description="Generate mapped Feed file for Store TO Fulfillment from NetSuite to update Shipment in OMS"
-           parentTypeId="LocalFeedFile"
-           sendPath="${contentRoot}/netsuite/OMSStoreToFulfillmentFeed/OMSStoreToFulfillmentFeed-${dateTime}-${systemMessageId}.json"
-           consumeServiceName="co.hotwax.system.FeedServices.generate#OMSFeed"
-           sendServiceName="co.hotwax.netsuite.TransferOrderServices.map#StoreTransferOrderFulfillment">
-    </moqui.service.message.SystemMessageType>
-
-    <moqui.basic.Enumeration description="Generate mapped Feed file from Store TO Fulfillment of NetSuite to Update TO Shipment in OMS" enumId="OMSUpdateTOShipmentFeed" enumTypeId="OMSMessageTypeEnum"/>
-    <moqui.basic.Enumeration description="Generate mapped Feed file of Store TO Fulfillment from NetSuite connector to OMS" enumId="GenerateOMSUpdateTOShipmentFeed" enumTypeId="NetsuiteMessageTypeEnum" relatedEnumId="OMSUpdateTOShipmentFeed" relatedEnumTypeId="OMSMessageTypeEnum"/>
-    <moqui.basic.Enumeration description="Import Store Fulfillment" enumId="ImportStoreToFulfillmentFeed" enumTypeId="NetsuiteMessageTypeEnum" relatedEnumId="GenerateOMSUpdateTOShipmentFeed" relatedEnumTypeId="NetsuiteMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Update Store TO Shipment Feed in OMS" enumId="OMSUpdateTOShipmentFeed" enumTypeId="OMSMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Import Store Fulfillment Feed from NetSuite" enumId="ImportStoreToFulfillmentFeed" enumTypeId="NetsuiteMessageTypeEnum" relatedEnumId="OMSUpdateTOShipmentFeed" relatedEnumTypeId="OMSMessageTypeEnum"/>
 
     <!-- System Message Type for Transfer Order Shipments Receipt Feed -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="TransferOrderShipmentReceiptFeed"

--- a/service/co/hotwax/netsuite/TransferOrderServices.xml
+++ b/service/co/hotwax/netsuite/TransferOrderServices.xml
@@ -73,56 +73,6 @@
         </actions>
     </service>
 
-    <service verb="map" noun="StoreTransferOrderFulfillment" transaction-timeout="1800">
-        <in-parameters>
-            <parameter name="payload" type="Map" required="true">
-                <description>The Transfer Order Fulfillment map from NetSuite to be mapped as per Shipment in OMS.</description>
-                <parameter name="shipmentId"/>
-                <parameter name="externalId"/>
-                <parameter name="items" type="List">
-                    <parameter name="itemMap" type="Map">
-                        <parameter name="externalId"/>
-                        <parameter name="productIdType"/>
-                        <parameter name="productIdValue"/>
-                    </parameter>
-                </parameter>
-            </parameter>
-        </in-parameters>
-        <out-parameters>
-            <parameter name="payload" type="Map">
-                <description>The Shipment map with mapped fields for OMS.</description>
-                <parameter name="shipmentId"/>
-                <parameter name="externalId"/>
-                <parameter name="items" type="List">
-                    <parameter name="itemMap" type="Map">
-                        <parameter name="shipmentItemSeqId"/>
-                        <parameter name="externalId"/>
-                        <parameter name="productId"/>
-                    </parameter>
-                </parameter>
-            </parameter>
-        </out-parameters>
-        <actions>
-            <iterate list="payload.items" entry="item">
-                <!-- Get HC Product ID -->
-                <entity-find entity-name="org.apache.ofbiz.product.product.GoodIdentification" list="goodIdentifications" limit="1">
-                    <econdition field-name="goodIdentificationTypeId" from="item.remove('productIdType')"/>
-                    <econdition field-name="idValue" from="item.remove('productIdValue')"/>
-                    <date-filter/>
-                    <order-by field-name="-fromDate"/>
-                </entity-find>
-                <set field="item.productId" from="goodIdentifications?.first?.productId"/>
-
-                <!-- Get shipment Item Seq ID  -->
-                <entity-find entity-name="org.apache.ofbiz.shipment.shipment.ShipmentItem" list="shipmentItemList">
-                    <econdition field-name="shipmentId" from="payload.shipmentId"/>
-                    <econdition field-name="productId" from="item.productId"/>
-                </entity-find>
-                <set field="item.shipmentItemSeqId" from="shipmentItemList?.first?.shipmentItemSeqId"/>
-            </iterate>
-        </actions>
-    </service>
-
     <!-- NOTE: Removed the support of productStoreId for now, TODO need to check in future for multi store setup -->
     <service verb="generate" noun="TransferOrderShipmentReceiptFeed" authenticate="anonymous-all" transaction-timeout="7200">
         <in-parameters>
@@ -443,7 +393,7 @@
                     </entity-find>
 
                     <!-- Set Shipment Item level details -->
-                    <set field="shipmentItemMap" from="[lineId:orderItemAttrList?.first?.attrValue, quantity:shipmentItem.quantity, tags:'hotwax-fulfilled']"/>
+                    <set field="shipmentItemMap" from="[shipmentItemSeqId:shipmentItem.shipmentItemSeqId, lineId:orderItemAttrList?.first?.attrValue, quantity:shipmentItem.quantity, tags:'hotwax-fulfilled']"/>
                     <script>items.add(shipmentItemMap)</script>
 
                     <!-- Create Order Fulfillment History record for each shipment item included in the feed -->

--- a/upgrade/v1.5.3/UpgradeData.xml
+++ b/upgrade/v1.5.3/UpgradeData.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="ext-upgrade-v1.5.3">
+
+    <moqui.basic.Enumeration description="Update Store TO Shipment Feed in OMS" enumId="OMSUpdateTOShipmentFeed" enumTypeId="OMSMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Import Store Fulfillment Feed from NetSuite" enumId="ImportStoreToFulfillmentFeed" enumTypeId="NetsuiteMessageTypeEnum" relatedEnumId="OMSUpdateTOShipmentFeed" relatedEnumTypeId="OMSMessageTypeEnum"/>
+
+</entity-facade-xml>


### PR DESCRIPTION
1. Included Shipment Item Seq Id in Store Transfer order Fulfillment feed.
2. Removed map#StoreTransferOrderFulfillment as it no longer needed since we will use shipmentItemSeqId to update the NS Fulfillment line ID in Shipment Item in OMS.
3. Updated the System Message Types, removed the not required GenerateOMSUpdateTOShipmentFeed SMT.